### PR TITLE
Fix detection: error: unrecognized arguments:

### DIFF
--- a/python/object_recognition_core/utils/parser.py
+++ b/python/object_recognition_core/utils/parser.py
@@ -12,9 +12,10 @@ class ObjectRecognitionParser(argparse.ArgumentParser):
 
     # copied and tweaked from http://bugs.python.org/issue10523
     def _read_args_from_files(self, arg_strings):
+        filtered_arg_strings = self.remove_launchfile_generated_args(arg_strings)
         # expand arguments referencing files
         new_arg_strings = []
-        for arg_string in arg_strings:
+        for arg_string in filtered_arg_strings:
 
             # for regular arguments, just add them back into the list
             if not arg_string or arg_string[0] not in self.fromfile_prefix_chars:
@@ -43,6 +44,14 @@ class ObjectRecognitionParser(argparse.ArgumentParser):
 
         # return the modified argument list
         return new_arg_strings
+
+    def remove_launchfile_generated_args(self, arg_strings):
+        new_arg_strings = []
+        for arg_string in arg_strings:
+            if not arg_string.startswith('__name:=') and not arg_string.startswith('__log:='):
+                new_arg_strings.append(arg_string)
+        return new_arg_strings
+
 
     # The following function should be the only one needed but the implementation is now broken in Python
     """


### PR DESCRIPTION
As of referenced in this issue: https://github.com/wg-perception/object_recognition_core/issues/20
When launching the detection (and maybe training too) we get the error:

```
usage: detection [-h] [-c CONFIG_FILE] [--visualize] [--niter ITERATIONS]
                 [--shell] [--gui] [--logfile LOGFILE] [--graphviz]
                 [--dotfile DOTFILE] [--stats]
detection: error: unrecognized arguments: __name:=clusters_detection __log:=/home/sampfeiffer/.ros/logs/94f5f7a0-b989-11e3-aa66-e0cb4e1f7c63/clusters_detection-4.log
[clusters_detection-4] process has died [pid 18346, exit code 2, cmd /home/sampfeiffer/public_workspaces/ork_ws/src/ork_core/apps/detection -c /home/sampfeiffer/public_workspaces/reem_manipulation_ws/src/reem_object_recognition/config/tabletop/detection.clusters.ros.ork.reem.throtled __name:=clusters_detection __log:=/home/sampfeiffer/.ros/logs/94f5f7a0-b989-11e3-aa66-e0cb4e1f7c63/clusters_detection-4.log].
log file: /home/sampfeiffer/.ros/logs/94f5f7a0-b989-11e3-aa66-e0cb4e1f7c63/clusters_detection-4*.log
```

This is because the arguments __name:= and __log:= are generated by the launchfile. So with this patch I'm filtering them out.
