### PR TITLE
Always include ecto.hpp first

### DIFF
--- a/include/object_recognition_core/db/ModelReader.h
+++ b/include/object_recognition_core/db/ModelReader.h
@@ -41,9 +41,9 @@
 #ifndef ork_db_model_reader
 #define ork_db_model_reader
 
-#include <boost/bind.hpp>
-
 #include <ecto/ecto.hpp>
+
+#include <boost/bind.hpp>
 
 #include <object_recognition_core/common/json_spirit/json_spirit_reader_template.h>
 #include <object_recognition_core/common/types.h>

--- a/src/filters/depth_filter.cpp
+++ b/src/filters/depth_filter.cpp
@@ -33,9 +33,9 @@
  *
  */
 
-#include <limits>
-
 #include <ecto/ecto.hpp>
+
+#include <limits>
 
 #include <opencv2/core/core.hpp>
 

--- a/src/io/Aggregator.cpp
+++ b/src/io/Aggregator.cpp
@@ -33,11 +33,11 @@
  *
  */
 
+#include <ecto/ecto.hpp>
+
 #include <boost/format.hpp>
 
 #include <opencv2/core/core.hpp>
-
-#include <ecto/ecto.hpp>
 
 #include <object_recognition_core/common/types.h>
 #include <object_recognition_core/common/pose_result.h>

--- a/src/io/GuessCsvWriter.cpp
+++ b/src/io/GuessCsvWriter.cpp
@@ -32,10 +32,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <ecto/ecto.hpp>
+
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
-
-#include <ecto/ecto.hpp>
 
 #include <opencv2/core/core.hpp>
 

--- a/src/io/GuessTerminalWriter.cpp
+++ b/src/io/GuessTerminalWriter.cpp
@@ -33,11 +33,11 @@
  *
  */
 
+#include <ecto/ecto.hpp>
+
 #include <iostream>
 
 #include <boost/foreach.hpp>
-
-#include <ecto/ecto.hpp>
 
 #include <opencv2/core/core.hpp>
 

--- a/src/io/PipelineInfo.cpp
+++ b/src/io/PipelineInfo.cpp
@@ -5,9 +5,9 @@
  *      Author: vrabaud
  */
 
-#include <iostream>
-
 #include <ecto/ecto.hpp>
+
+#include <iostream>
 
 #include <object_recognition_core/common/json.hpp>
 

--- a/src/pipelines/ConstantPipeline.cpp
+++ b/src/pipelines/ConstantPipeline.cpp
@@ -33,12 +33,12 @@
  *
  */
 
+#include <ecto/ecto.hpp>
+
 #include <stdlib.h>
 #include <string>
 
 #include <Eigen/Core>
-
-#include <ecto/ecto.hpp>
 
 #include <object_recognition_core/common/pose_result.h>
 #include <object_recognition_core/db/db.h>


### PR DESCRIPTION
`ecto.hpp` includes `Python.hpp`, which must always come before system includes. This bug blocks builds on Fedora entirely.

Example of breakage: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-object-recognition-core_binaryrpm_heisenbug_i386/23/console

Thanks,

--scott
