### PR TITLE
Don't throw when database is empty

### DIFF
--- a/src/common/object_info.cpp
+++ b/src/common/object_info.cpp
@@ -61,9 +61,9 @@ namespace object_recognition_core
         }
       }
 
-      // Make sure the db_ is valid
       if (db_->parameters().type() == db::ObjectDbParameters::EMPTY)
-        throw std::runtime_error("Db not set in the ObjectInfo");
+        // nothing to do
+        return;
 
   // Get information about the object
   or_json::mObject fields;


### PR DESCRIPTION
There is no need to throw here. The function load_fields_and_attachments works
quite nicely for an empty database. The only thing it has to do is return...

This makes it possible to use the rviz plugin OrkObject without a valid
database (This obviously doesn't show meshes or the name then, but it's still
useful as it prints confidence values and the object's key.